### PR TITLE
feat(machine-config): add kubelet extra mounts

### DIFF
--- a/nodes.tf
+++ b/nodes.tf
@@ -30,19 +30,7 @@ resource "talos_machine_configuration_apply" "this" {
         ntp_server           = var.talos.node_data.ntp_endpoint
         api_server           = var.talos.cluster.api_server
         subnet               = var.talos.node_data.subnet
-        extra_mounts         = length(coalesce(var.talos.cluster.extra_mounts, {})) > 0 ? join("\n", [
-  "    extraMounts:",
-  join("\n", [
-    for mount in var.talos.cluster.extra_mounts : 
-    join("\n", [
-      "      - destination: ${mount.path}",
-      "        type: ${mount.type}",
-      "        source: ${mount.path}",
-      "        options:",
-      join("\n", [for option in mount.options : "          - ${option}"])
-    ])
-  ])
-]) : ""
+        extra_mounts        =  var.talos.cluster.extra_mounts
       })
     ],
     # Control Plane only templates

--- a/nodes.tf
+++ b/nodes.tf
@@ -30,6 +30,19 @@ resource "talos_machine_configuration_apply" "this" {
         ntp_server           = var.talos.node_data.ntp_endpoint
         api_server           = var.talos.cluster.api_server
         subnet               = var.talos.node_data.subnet
+        extra_mounts         = length(coalesce(var.talos.cluster.extra_mounts, {})) > 0 ? join("\n", [
+  "    extraMounts:",
+  join("\n", [
+    for mount in var.talos.cluster.extra_mounts : 
+    join("\n", [
+      "      - destination: ${mount.path}",
+      "        type: ${mount.type}",
+      "        source: ${mount.path}",
+      "        options:",
+      join("\n", [for option in mount.options : "          - ${option}"])
+    ])
+  ])
+]) : ""
       })
     ],
     # Control Plane only templates

--- a/nodes.tf
+++ b/nodes.tf
@@ -30,7 +30,7 @@ resource "talos_machine_configuration_apply" "this" {
         ntp_server           = var.talos.node_data.ntp_endpoint
         api_server           = var.talos.cluster.api_server
         subnet               = var.talos.node_data.subnet
-        extra_mounts        =  var.talos.cluster.extra_mounts
+        extra_mounts         = var.talos.cluster.extra_mounts
       })
     ],
     # Control Plane only templates

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -37,6 +37,4 @@ machine:
     nodeIP:
       validSubnets:
         - ${subnet}
-
-
-
+${extra_mounts}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -51,6 +51,5 @@ machine:
           %{~ endfor ~}
         %{~ endif ~}
       %{~ endfor ~}
-    %{~ else ~}
     %{~ endif ~}
     %{~ endif ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -37,6 +37,7 @@ machine:
     nodeIP:
       validSubnets:
         - ${subnet}
+    %{~ if extra_mounts != null ~}
     %{~ if length(extra_mounts) > 0 ~}
     extraMounts:
       %{~ for mount in extra_mounts ~}
@@ -49,4 +50,5 @@ machine:
         %{~ endfor ~}
       %{~ endfor ~}
     %{~ else ~}
+    %{~ endif ~}
     %{~ endif ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -38,7 +38,6 @@ machine:
       validSubnets:
         - ${subnet}
     %{~ if extra_mounts != null ~}
-    %{~ if length(extra_mounts) > 0 ~}
     extraMounts:
       %{~ for mount in extra_mounts ~}
       - destination: ${mount.destination}
@@ -51,5 +50,4 @@ machine:
           %{~ endfor ~}
         %{~ endif ~}
       %{~ endfor ~}
-    %{~ endif ~}
     %{~ endif ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -41,9 +41,9 @@ machine:
     %{~ if length(extra_mounts) > 0 ~}
     extraMounts:
       %{~ for mount in extra_mounts ~}
-      - destination: ${mount.path}
+      - destination: ${mount.dst_path}
         type: ${mount.type}
-        source: ${mount.path}
+        source: ${mount.src_path}
         %{~ if mount.options != null ~}
         options:
           %{~ if length(mount.options) > 0 ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -37,4 +37,16 @@ machine:
     nodeIP:
       validSubnets:
         - ${subnet}
-${extra_mounts}
+    %{~ if length(extra_mounts) > 0 ~}
+    extraMounts:
+      %{~ for mount in extra_mounts ~}
+      - destination: ${mount.path}
+        type: ${mount.type}
+        source: ${mount.path}
+        options:
+        %{~ for option in mount.options ~}
+          - ${option}
+        %{~ endfor ~}
+      %{~ endfor ~}
+    %{~ else ~}
+    %{~ endif ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -46,11 +46,9 @@ machine:
         source: ${mount.source}
         %{~ if mount.options != null ~}
         options:
-          %{~ if length(mount.options) > 0 ~}
           %{~ for option in mount.options ~}
           - ${option}
           %{~ endfor ~}
-          %{~ endif ~}
         %{~ endif ~}
       %{~ endfor ~}
     %{~ else ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -41,9 +41,9 @@ machine:
     %{~ if length(extra_mounts) > 0 ~}
     extraMounts:
       %{~ for mount in extra_mounts ~}
-      - destination: ${mount.dst_path}
+      - destination: ${mount.destination}
         type: ${mount.type}
-        source: ${mount.src_path}
+        source: ${mount.source}
         %{~ if mount.options != null ~}
         options:
           %{~ if length(mount.options) > 0 ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -45,9 +45,11 @@ machine:
         type: ${mount.type}
         source: ${mount.path}
         options:
+        %{~ if length(mount.options) > 0 ~}
         %{~ for option in mount.options ~}
           - ${option}
         %{~ endfor ~}
+        %{~ endif ~}
       %{~ endfor ~}
     %{~ else ~}
     %{~ endif ~}

--- a/templates/global.yaml.tmpl
+++ b/templates/global.yaml.tmpl
@@ -44,11 +44,13 @@ machine:
       - destination: ${mount.path}
         type: ${mount.type}
         source: ${mount.path}
+        %{~ if mount.options != null ~}
         options:
-        %{~ if length(mount.options) > 0 ~}
-        %{~ for option in mount.options ~}
+          %{~ if length(mount.options) > 0 ~}
+          %{~ for option in mount.options ~}
           - ${option}
-        %{~ endfor ~}
+          %{~ endfor ~}
+          %{~ endif ~}
         %{~ endif ~}
       %{~ endfor ~}
     %{~ else ~}

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,10 @@ variable "talos" {
       api_server         = string
       kubernetes_version = string
       talos_version      = string
-      extra_mounts       = optional(map(object({
+      extra_mounts       = optional(list(object({
         path    = string
         type    = string
-        options = list(string)
+        options = optional(list(string))
         })))
     })
     node_data = object({

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "talos" {
       api_server         = string
       kubernetes_version = string
       talos_version      = string
+      extra_mounts       = optional(map(object({
+        path    = string
+        type    = string
+        options = list(string)
+        })))
     })
     node_data = object({
       disk_size            = string

--- a/variables.tf
+++ b/variables.tf
@@ -12,9 +12,10 @@ variable "talos" {
       kubernetes_version = string
       talos_version      = string
       extra_mounts       = optional(list(object({
-        path    = string
-        type    = string
-        options = optional(list(string))
+        dst_path  = string
+        src_path  = string
+        type      = string
+        options   = optional(list(string))
         })))
     })
     node_data = object({

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,11 @@ variable "talos" {
       kubernetes_version = string
       talos_version      = string
       extra_mounts       = optional(list(object({
-        dst_path  = string
-        src_path  = string
-        type      = string
-        options   = optional(list(string))
-        })))
+        destination   = string
+        source        = string
+        type          = string
+        options       = optional(list(string))
+      })))
     })
     node_data = object({
       disk_size            = string


### PR DESCRIPTION
### New feature

**Required additions to variables.tf:** 

      extra_mounts       = optional(map(object({
        path    = string
        type    = string
        options = list(string)
        })))

**Usage:** 

If extra_mounts left un defined in auto.tfvars, then no additional mount points will be added.  
Use the following structure to add add additional mount points

    extra_mounts       =     {
      "openebs" = {
        path    = "/var/openebs/local"
        type    = "bind"
        options = ["rbind", "rshared", "rw"]
      }
    }

 
